### PR TITLE
Create Dockerfile for convenience

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM fedora:29
+
+COPY . /usr/src/bang
+WORKDIR /usr/src/bang/src
+
+RUN dnf update -y && \
+    dnf install -y python3 \
+                   binutils \
+                   squashfs-tools \
+                   cabextract \
+                   p7zip \
+                   e2tools \
+                   zstd \
+                   python3-lz4 \
+                   qemu-img \
+                   python3-psycopg2 \
+                   python3-snappy \
+                   python3-tlsh \
+                   python3-tinycss2 \
+                   python3-dockerfile-parse \
+                   openssl \
+                   rzip \
+                   libxml2 \
+                   mailcap \
+                   lzop
+
+CMD ["python3","bangshell"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,24 +4,25 @@ COPY . /usr/src/bang
 WORKDIR /usr/src/bang/src
 
 RUN dnf update -y && \
-    dnf install -y python3 \
-                   binutils \
-                   squashfs-tools \
+    dnf install -y binutils \
                    cabextract \
-                   p7zip \
                    e2tools \
-                   zstd \
+                   libxml2 \
+                   lzop \
+                   mailcap \
+                   openssl \
+                   p7zip \
+                   python3 \
+                   python3-dockerfile-parse \
                    python3-lz4 \
-                   qemu-img \
+                   python3-pillow \
                    python3-psycopg2 \
                    python3-snappy \
-                   python3-tlsh \
                    python3-tinycss2 \
-                   python3-dockerfile-parse \
-                   openssl \
+                   python3-tlsh \
+                   qemu-img \
                    rzip \
-                   libxml2 \
-                   mailcap \
-                   lzop
+                   squashfs-tools \
+                   zstd
 
 CMD ["python3","bangshell"]


### PR DESCRIPTION
To build, just run:

```terminal
docker build -t bang .
```

By default, it will load the `bangshell`, however, this can be overridden:

```terminal
docker run -it bang:latest /bin/bash
```

Also, the source tree in question can be mounted as a volume:

```terminal
docker run -v ./src:/usr/src/code -it bang:latest /bin/bash
```

Finally, `postresql` can be run in an accompanying container for persistence:

```terminal
docker pull postgres
```