### PR TITLE
Added ncompress as dependency into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN dnf update -y && \
                    qemu-img \
                    rzip \
                    squashfs-tools \
-                   zstd
+                   zstd \
+                   ncompress
 
 CMD ["python3","bangshell"]


### PR DESCRIPTION
Inside docker, the ncompress dependency is missing , so it is crashing:

Process Process-2:
Traceback (most recent call last):
  File "/usr/lib64/python3.7/multiprocessing/process.py", line 297, in _bootstrap
    self.run()
  File "/usr/lib64/python3.7/multiprocessing/process.py", line 99, in run
    self._target(*self._args, **self._kwargs)
  File "bang-scanner", line 677, in processfile
    unpackresult = bangsignatures.signaturetofunction[signature](filename, offset, dataunpackdirectory, temporarydirectory)
  File "/usr/src/bang/src/bangunpack.py", line 16164, in unpackCompress
    p = subprocess.Popen(['uncompress'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "/usr/lib64/python3.7/subprocess.py", line 775, in __init__
    restore_signals, start_new_session)
  File "/usr/lib64/python3.7/subprocess.py", line 1522, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'uncompress': 'uncompress'