### PR TITLE
Add hints to README on where to find scan results

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ larger file, unless stated otherwise.
 
     $ python3 bang-scanner -c bang.config -f /path/to/binary
 
+Depending on the `baseunpackdirectory` defined in your `bang.config`, the results
+will be found in `~/tmp/report.txt`, for instance.  You may also enable an additional
+JSON output, PostgrSQL or ElasticSearch server to write results to.
+
 ## License
 
 GNU Affero General Public License, version 3 (AGPL-3.0)


### PR DESCRIPTION
Since BANG is by default writing output to `~/tmp` and not to the current directory, it may easily happen that a new user wonders where to look for the resulting report. (See issue #149)