### PR TITLE
android_fbpk: crapshot at processing fbpk v2. A lot of data is still

### DIFF
--- a/src/parsers/firmware/android_fbpk/UnpackParser.py
+++ b/src/parsers/firmware/android_fbpk/UnpackParser.py
@@ -30,7 +30,8 @@ from kaitaistruct import ValidationFailedError
 from . import android_fbpk
 
 
-# test file: redfin-rd1a.200810.020-factory-c3ea1715.zip
+# v1 test file: redfin-rd1a.200810.020-factory-c3ea1715.zip
+# v2 test file: raven-sd1a.210817.015.a4-factory-bd6cb030.zip
 class AndroidFbpkUnpackParser(UnpackParser):
     extensions = []
     signatures = [
@@ -41,19 +42,31 @@ class AndroidFbpkUnpackParser(UnpackParser):
     def parse(self):
         try:
             self.data = android_fbpk.AndroidFbpk.from_io(self.infile)
+            # version 2 needs some extra sanity checks
+            # read data to trigger evaluation
+            if self.data.header.version == 2:
+                for entry in self.data.body.entries:
+                    # read the parsed partition to trigger
+                    # parsing for FBPT entries
+                    data = entry.partition_parsed
         except (Exception, ValidationFailedError) as e:
             raise UnpackParserException(e.args)
+        self.unpacked_size = self.data.body.total_file_size
 
     # no need to carve from the file
     def carve(self):
         pass
 
+    # make sure that self.unpacked_size is not overwritten
+    def calculate_unpacked_size(self):
+        pass
+
     def unpack(self):
         unpacked_files = []
         seen_partitions = set()
-        for entry in self.data.entries:
+        for entry in self.data.body.entries:
             out_labels = []
-            # only consider "real" partitions, not partition tables
+            # only consider "real" partitions
             if entry.type == 0:
                 continue
             partition_name = entry.partition_name

--- a/src/parsers/firmware/android_fbpk/android_fbpk.ksy
+++ b/src/parsers/firmware/android_fbpk/android_fbpk.ksy
@@ -8,12 +8,12 @@ doc-ref: https://github.com/anestisb/qc_image_unpacker/blob/master/src/packed_im
 seq:
   - id: header
     type: header
-  - id: entries
-    type: entry
-    repeat: until
-    repeat-until: _index == header.num_entries - 1
-    if: header.num_entries != 0
-
+  - id: body
+    type:
+      switch-on: header.version
+      cases:
+        1: bodyv1
+        2: bodyv2
 types:
   header:
     seq:
@@ -21,14 +21,44 @@ types:
         contents: "FBPK"
       - id: version
         type: u4
-        valid: 1
+        valid:
+          any-of: [1, 2]
+  bodyv1:
+    seq:
       - id: img_version
         size: 68
       - id: num_entries
         type: u4
       - id: total_file_size
         type: u4
-  entry:
+      - id: entries
+        type: entryv1
+        repeat: until
+        repeat-until: (_index == num_entries - 1) or _io.eof
+        if: num_entries != 0
+  bodyv2:
+    seq:
+      - id: unknown1
+        type: u4
+        # ofset of entries?
+      - id: len_entry
+        type: u4
+      - id: chip_id
+        size: 16
+      - id: img_version
+        size: 68
+      - id: unknown2
+        type: u4
+      - id: num_entries
+        type: u4
+      - id: total_file_size
+        type: u4
+      - id: entries
+        type: entryv2(total_file_size)
+        size: len_entry
+        repeat: expr
+        repeat-expr: num_entries
+  entryv1:
     seq:
       - id: type
         type: u4
@@ -47,14 +77,54 @@ types:
         type: u4
       - id: partition
         size: len_partition
-        type:
-          switch-on: type
-          cases:
-            0: fbpt
       - id: padding3
         size: next_offset - _io.pos
-        if: next_offset <= _root.header.total_file_size
-  fbpt:
+        if: next_offset <= _parent.total_file_size
+  entryv2:
+    params:
+      - id: total_file_size
+        type: u4
+    seq:
+      - id: unknown1
+        size: 4
+      - id: partition_name
+        size: 76
+        type: strz
+      - id: ofs_partition
+        type: u4
+        valid:
+          max: total_file_size
+      - id: unknown2
+        size: 4
+      - id: len_partition
+        type: u4
+        valid:
+          max: total_file_size - ofs_partition
+      - id: unknown3
+        size: 4
+      - id: type
+        type: u4
+      - id: unknown4
+        size: 4
+    instances:
+      partition:
+        pos: ofs_partition
+        size: len_partition
+        io: _root._io
+      partition_parsed:
+        pos: ofs_partition
+        size: len_partition
+        io: _root._io
+        type:
+          switch-on: magic
+          cases:
+            0x54504246: fbptv2
+      magic:
+        pos: ofs_partition
+        type: u4
+        io: _root._io
+        if: len_partition >= 4
+  fbptv1:
     seq:
       - id: magic
         contents: "FBPT"
@@ -74,6 +144,30 @@ types:
       - id: entries
         type: fbpt_entry
         repeat: eos
+  fbptv2:
+    seq:
+      - id: magic
+        contents: "FBPT"
+      - id: type
+        type: u4
+        enum: fbpt_types
+      - id: lun
+        type: u4
+      - id: unknown1
+        size: 4
+      - id: num_partitions
+        type: u4
+
+      - id: unknown2
+        size: 37
+      - id: padding
+        size: 3
+      - id: unknown3
+        size: 4
+      - id: entries
+        type: fbpt_entryv2
+        repeat: expr
+        repeat-expr: num_partitions
   fbpt_entry:
     seq:
       - id: size
@@ -93,6 +187,25 @@ types:
         type: strz
       - id: padding
         size: 2
+  fbpt_entryv2:
+    seq:
+      - id: size
+        type: u4
+      - id: unknown
+        size: 4
+      - id: attributes
+        type: u4
+      - id: partition_name
+        size: 36
+        type: strz
+      - id: type_guid
+        size: 37
+        type: strz
+      - id: partition_guid
+        size: 37
+        type: strz
+      - id: file_system_type
+        size: 14
 
 enums:
   fbpt_types:


### PR DESCRIPTION
A lot of data is still unknown. fbpt entries and some other entries are unpacked correctly,
but the other entries (abl, gsa, ldfw, etc.) seem to have an extra
0x400 or 0x1000 header with some data that might or might not be
relevant. There is no (known) documentation for these files.