### PR TITLE
shell.nix: Ensure that any installed pyahocorasick is built for byte-strings

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -3,7 +3,17 @@ let
   # See https://github.com/nmattia/niv/
   sources = import ./nix/sources.nix;
 
-  pkgs = import sources.nixpkgs { config.allowUnfree = true; overlays = []; };
+  pyahocorasickOverlay = _final: prev: {
+    python3 = prev.python3.override {
+      packageOverrides = _pyFinal: pyPrev: {
+        pyahocorasick = pyPrev.pyahocorasick.overrideAttrs (oldAttrs: {
+          preBuild = (oldAttrs.preBuild or "") + "export AHOCORASICK_BYTES=1";
+        });
+      };
+    };
+  };
+
+  pkgs = import sources.nixpkgs { config.allowUnfree = true; overlays = [ pyahocorasickOverlay ]; };
 
   my-python = pkgs.python3.withPackages (p: with p; [
     brotli


### PR DESCRIPTION
This should work as-is, without the need for updating the Nixpkgs pin.