### PR TITLE
add support for unpacking granite devices firmware files (STM32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ larger file, unless stated otherwise.
 178. Reolink 'logo' file
 179. FLS firmware files (IP cameras)
 180. TP-Link TX6610v4 firmware
+181. Granite Devices firmware v300
 
 The following text formats can be recognized:
 

--- a/src/bang/parsers/firmware/gdfw/UnpackParser.py
+++ b/src/bang/parsers/firmware/gdfw/UnpackParser.py
@@ -1,0 +1,59 @@
+# Binary Analysis Next Generation (BANG!)
+#
+# This file is part of BANG.
+#
+# BANG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License, version 3,
+# as published by the Free Software Foundation.
+#
+# BANG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License, version 3, along with BANG.  If not, see
+# <http://www.gnu.org/licenses/>
+#
+# Copyright Armijn Hemel
+# Licensed under the terms of the GNU Affero General Public License
+# version 3
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import pathlib
+
+from bang.UnpackParser import UnpackParser, check_condition
+from bang.UnpackParserException import UnpackParserException
+from kaitaistruct import ValidationFailedError
+from . import gdfw
+
+
+class GdfwUnpackParser(UnpackParser):
+    extensions = []
+    signatures = [
+        (0, b'GDFW')
+    ]
+    pretty_name = 'gdfw'
+
+    def parse(self):
+        self.unpacked_size = 0
+        try:
+            self.data = gdfw.Gdfw.from_io(self.infile)
+        except (Exception, ValidationFailedError) as e:
+            raise UnpackParserException(e.args)
+
+    def unpack(self, meta_directory):
+        if self.data.header.len_hostfw != 0:
+            file_path = pathlib.Path('hostfw')
+            with meta_directory.unpack_regular_file(file_path) as (unpacked_md, outfile):
+                outfile.write(self.data.hostfw)
+                yield unpacked_md
+
+        if self.data.header.len_gcfw != 0:
+            file_path = pathlib.Path('gcfw')
+            with meta_directory.unpack_regular_file(file_path) as (unpacked_md, outfile):
+                outfile.write(self.data.hostfw)
+                yield unpacked_md
+
+    labels = ['gdfw', 'firmware']
+    metadata = {}

--- a/src/bang/parsers/firmware/gdfw/gdfw.ksy
+++ b/src/bang/parsers/firmware/gdfw/gdfw.ksy
@@ -1,0 +1,45 @@
+meta:
+  id: gdfw
+  title: Granite Devices firmware
+  license: CC0-1.0
+  endian: le
+  encoding: UTF-8
+doc-ref:
+  - https://granitedevices.com/wiki/Firmware_file_format_(.gdf)
+seq:
+  - id: header
+    type: header
+  - id: hostfw
+    size: header.len_hostfw
+  - id: gcfw
+    size: header.len_gcfw
+  - id: checksum
+    type: u4
+types:
+  header:
+    seq:
+      - id: magic
+        contents: 'GDFW'
+      - id: version
+        type: u2
+        valid: 300
+      - id: target_drive_type
+        type: u2
+        enum: target_drive_types
+        valid:
+          any-of:
+            - target_drive_types::argon
+            - target_drive_types::ion
+            - target_drive_types::atomi
+      - id: len_hostfw
+        type: u4
+      - id: gcfw_len
+        type: u4
+    instances:
+      len_gcfw:
+        value: 'gcfw_len == 0xffffffff ? 0 : gcfw_len'
+enums:
+  target_drive_types:
+     4000: argon
+     11000: ion
+     14000: atomi


### PR DESCRIPTION
This unpacker only writes the contents of several of the firmware bits but does not do any extensive parsing.