### PR TITLE
erofs "inline" data layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ larger file, unless stated otherwise.
 179. FLS firmware files (IP cameras)
 180. TP-Link TX6610v4 firmware
 181. Granite Devices firmware v300
+182. erofs ('inline' data layout only)
 
 The following text formats can be recognized:
 

--- a/src/bang/parsers/filesystem/erofs/UnpackParser.py
+++ b/src/bang/parsers/filesystem/erofs/UnpackParser.py
@@ -46,7 +46,7 @@ class ErofsUnpacker(UnpackParser):
 
             # walk the inodes
             inodes = collections.deque()
-            inodes.append(('', '/', erofs.Erofs.FileTypes.directory, self.data.root_inode))
+            inodes.append(('', '', erofs.Erofs.FileTypes.directory, self.data.root_inode))
             while True:
                 try:
                     name, parent, file_type, inode = inodes.popleft()

--- a/src/bang/parsers/filesystem/erofs/UnpackParser.py
+++ b/src/bang/parsers/filesystem/erofs/UnpackParser.py
@@ -1,0 +1,121 @@
+# Binary Analysis Next Generation (BANG!)
+#
+# This file is part of BANG.
+#
+# BANG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License, version 3,
+# as published by the Free Software Foundation.
+#
+# BANG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License, version 3, along with BANG.  If not, see
+# <http://www.gnu.org/licenses/>
+#
+# Copyright Armijn Hemel
+# Licensed under the terms of the GNU Affero General Public License
+# version 3
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import collections
+import os
+import pathlib
+
+from bang.UnpackParser import UnpackParser, check_condition
+from bang.UnpackParserException import UnpackParserException
+from kaitaistruct import ValidationFailedError
+from . import erofs
+
+
+class ErofsUnpacker(UnpackParser):
+    extensions = []
+    signatures = [
+        (1024, b'\xe2\xe1\xf5\xe0')
+    ]
+    pretty_name = 'erofs'
+
+    def parse(self):
+        try:
+            self.data = erofs.Erofs.from_io(self.infile)
+
+            # force read the data to force Kaitai Struct to evaluate
+            nr_of_blocks = len(self.data.blocks)
+
+            # walk the inodes
+            inodes = collections.deque()
+            inodes.append(('', '/', erofs.Erofs.FileTypes.directory, self.data.root_inode))
+            while True:
+                try:
+                    name, parent, file_type, inode = inodes.popleft()
+
+                    # only process "inline" inodes for now
+                    check_condition(inode.inode_layout == erofs.Erofs.Inode.Layouts.inline,
+                                    "only inline inodes supported for now")
+
+                    if inode.inode.is_dir:
+                        check_condition(file_type == erofs.Erofs.FileTypes.directory,
+                                            "directory not declared as directory")
+                        # recurse into the directory tree
+                        for d in inode.data.dir_entries.entries:
+                            if d.name.name in ['.', '..']:
+                                # sanity check: make sure these are tagged as 'directory'
+                                check_condition(d.file_type == erofs.Erofs.FileTypes.directory,
+                                                "directory not declared as directory")
+                                continue
+                            inodes.append((d.name.name, name, d.file_type, d.inode))
+                    elif inode.inode.is_regular:
+                        check_condition(file_type == erofs.Erofs.FileTypes.regular_file,
+                                            "directory not declared as directory")
+                        # force read the data to force Kaitai Struct to evaluate
+                        d = inode.data.node_data
+                    elif inode.inode.is_link:
+                        check_condition(file_type == erofs.Erofs.FileTypes.symlink,
+                                            "directory not declared as directory")
+                except IndexError:
+                    break
+        except (Exception, ValidationFailedError) as e:
+            raise UnpackParserException(e.args)
+
+    # make sure that self.unpacked_size is not overwritten
+    def calculate_unpacked_size(self):
+        self.unpacked_size = self.data.superblock.header.len_file
+
+    def unpack(self, meta_directory):
+        inodes = collections.deque()
+        inodes.append(('', '', erofs.Erofs.FileTypes.directory, self.data.root_inode))
+        while True:
+            try:
+                name, parent, file_type, inode = inodes.popleft()
+                file_path = pathlib.Path(parent, name)
+
+                if inode.inode.is_dir:
+                    if file_path.name != '':
+                        meta_directory.unpack_directory(file_path)
+
+                    # recurse into the directory tree
+                    for d in inode.data.dir_entries.entries:
+                        if d.name.name in ['.', '..']:
+                            continue
+                        inodes.append((d.name.name, name, d.file_type, d.inode))
+                elif inode.inode.is_regular:
+                    with meta_directory.unpack_regular_file(file_path) as (unpacked_md, outfile):
+                        outfile.write(inode.data.node_data)
+                        outfile.write(inode.data.last_inline_data)
+                        yield unpacked_md
+                elif inode.inode.is_link:
+                    target = pathlib.Path(inode.data.link_data)
+                    meta_directory.unpack_symlink(file_path, target)
+
+            except IndexError:
+                break
+
+    labels = ['erofs', 'filesystem']
+
+    @property
+    def metadata(self):
+        metadata = {'uuid': self.data.superblock.header.uuid}
+        metadata['name'] = self.data.superblock.header.volume_name
+        return metadata

--- a/src/bang/parsers/filesystem/erofs/erofs.ksy
+++ b/src/bang/parsers/filesystem/erofs/erofs.ksy
@@ -4,7 +4,9 @@ meta:
   license: Apache-2.0
   encoding: UTF-8
   endian: le
-doc-ref: https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git
+doc-ref:
+  - https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git
+  - https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/tree/include/erofs_fs.h
 seq:
   - id: data
     size: 1024

--- a/src/bang/parsers/filesystem/erofs/erofs.ksy
+++ b/src/bang/parsers/filesystem/erofs/erofs.ksy
@@ -139,7 +139,9 @@ types:
         type:
           switch-on: inode_layout
           cases:
+            #layouts::plain: plain
             layouts::inline: inline
+            #layouts::compression: compression
     instances:
       extended:
         value: format & 0x01 == 0x01
@@ -149,6 +151,19 @@ types:
       len_inode:
         value: 'extended ? inode.body.as<extended_inode>.len_inode : inode.body.as<compact_inode>.len_inode'
     types:
+      compression:
+        seq:
+          - id: map_header
+            type: map_header
+      #plain:
+      #  instances:
+      #    node_data:
+      #      io: _root._io
+      #      pos: raw_block_address * _root.superblock.magic_header.block_size
+      #      size: '(_parent.len_inode / _root.superblock.magic_header.block_size) * _root.superblock.magic_header.block_size'
+      #      if: _parent.inode.is_regular
+      #    raw_block_address:
+      #      value: '_parent.extended ? _parent.inode.body.as<extended_inode>.specific.raw_block_address : _parent.inode.body.as<compact_inode>.specific.raw_block_address'
       inline:
         # for the inline data: the metadata for every format except
         # regular files is kept inline. For regular files, if the

--- a/src/bang/parsers/filesystem/erofs/erofs.ksy
+++ b/src/bang/parsers/filesystem/erofs/erofs.ksy
@@ -12,9 +12,9 @@ seq:
     type: superblock
 instances:
   root_inode:
-    pos: inode_offset_base + 32 * superblock.header.root_nid
+    pos: ofs_metadata_area + 32 * superblock.header.root_nid
     type: inode
-  inode_offset_base:
+  ofs_metadata_area:
     value: superblock.header.meta_block_address * superblock.magic_header.block_size
 types:
   superblock:
@@ -115,9 +115,14 @@ types:
       #  type: xattr
       #  repeat: expr
       #  repeat-expr: inode.num_xattr
-      - id: data
+      - id: dir_entries
         size: len_inode
         type: directory_entries
+        if: inode.is_dir
+      - id: link_data
+        size: len_inode
+        type: strz
+        if: inode.is_link
     instances:
       extended:
         value: format & 0x01 == 0x01
@@ -219,6 +224,12 @@ types:
         type: u4
         repeat: expr
         repeat-expr: num_shared_count
+  chunk_info:
+    seq:
+      - id: format
+        type: u2
+      - id: reserved
+        size: 2
   directory_entries:
     seq:
       - id: entries
@@ -265,7 +276,7 @@ types:
     instances:
       inode:
         io: _root._io
-        pos: _root.inode_offset_base + 32 * node_id
+        pos: _root.ofs_metadata_area + 32 * node_id
         type: inode
 enums:
   file_types:

--- a/src/bang/parsers/filesystem/erofs/erofs.ksy
+++ b/src/bang/parsers/filesystem/erofs/erofs.ksy
@@ -79,6 +79,7 @@ types:
         doc: 128-bit uuid for volume
       - id: volume_name
         size: 16
+        type: strz
       - id: feature_incompat_flags
         type: u4
       - id: compression_information

--- a/src/bang/parsers/filesystem/erofs/erofs.ksy
+++ b/src/bang/parsers/filesystem/erofs/erofs.ksy
@@ -149,6 +149,12 @@ types:
         value: 'extended ? inode.body.as<extended_inode>.len_inode : inode.body.as<compact_inode>.len_inode'
     types:
       inline:
+        # for the inline data: the metadata for every format except
+        # regular files is kept inline. For regular files, if the
+        # data is larger than the block size as defined in the superblock
+        # it can be found at the address found in the node specific
+        # information found in the inode information, except for the
+        # last bit of data if it cannot fill a full block.
         seq:
           - id: dir_entries
             size: _parent.len_inode
@@ -270,9 +276,13 @@ types:
         pos: 0
         type: u4
       chunk_info:
+        # information specifif for the chunked data layout
         pos: 0
         type: chunk_info
   xattrs:
+    # the xattr space consists of a header, an array of ids for
+    # shared xattr, which are offsets to xattrs somewhere else in
+    # the file. The rest of the data is used for inline xattrs.
     params:
       - id: num_inline_xattr
         type: u4

--- a/src/bang/parsers/filesystem/erofs/erofs.ksy
+++ b/src/bang/parsers/filesystem/erofs/erofs.ksy
@@ -4,6 +4,12 @@ meta:
   license: Apache-2.0
   encoding: UTF-8
   endian: le
+doc: |
+  Enhanced Read Only File System (erofs) is a file system for use on flash
+  storage. It is used on Android, as well as for cloud services (particularly
+  Alibaba's cloud solution).
+
+  Test files can be easily created using mkfs.erofs from erofs-utils.
 doc-ref:
   - https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git
   - https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/tree/include/erofs_fs.h

--- a/src/bang/parsers/filesystem/erofs/erofs.ksy
+++ b/src/bang/parsers/filesystem/erofs/erofs.ksy
@@ -12,8 +12,10 @@ seq:
     type: superblock
 instances:
   root_inode:
-    pos: superblock.header.meta_block_address * superblock.magic_header.block_size + 32 * superblock.header.root_nid
+    pos: inode_offset_base + 32 * superblock.header.root_nid
     type: inode
+  inode_offset_base:
+    value: superblock.header.meta_block_address * superblock.magic_header.block_size
 types:
   superblock:
     seq:
@@ -244,7 +246,7 @@ types:
           name:
             pos: _parent.entries[index].ofs_name
             size: len_name
-            type: str
+            type: strz
   directory_entry:
     params:
       - id: index
@@ -260,14 +262,10 @@ types:
         enum: file_types
       - id: reserved
         type: u1
-    instances:
-      len_name:
-        #value: _parent.entries[index+1].ofs_name - ofs_name
-        value: 1
-      name:
-        pos: ofs_name
-        size: len_name
-        type: str
+      inode:
+        io: _root._io
+        pos: _root.inode_offset_base + 32 * node_id
+        type: inode
 enums:
   file_types:
     0: unknown

--- a/src/bang/parsers/filesystem/erofs/erofs.ksy
+++ b/src/bang/parsers/filesystem/erofs/erofs.ksy
@@ -131,6 +131,7 @@ types:
         type: ondisk_inode(extended)
       - id: xattrs
         type: xattrs(inode.num_xattr)
+        if: inode.num_xattr != 0
       - id: data
         type:
           switch-on: inode_layout
@@ -155,6 +156,10 @@ types:
             size: _parent.len_inode
             type: strz
             if: _parent.inode.is_link
+        #instances:
+          #node_data:
+            #io: _root.io
+            #pos: 
     enums:
       layouts:
         0: plain

--- a/src/bang/parsers/filesystem/erofs/erofs.ksy
+++ b/src/bang/parsers/filesystem/erofs/erofs.ksy
@@ -419,6 +419,18 @@ types:
       - id: cluster_bits
         type: u1
     instances:
+      compacted_2b:
+        value: advise & 0x1 == 0x1
+      big_pcluster_1:
+        value: advise & 0x2 == 0x2
+      big_pcluster_2:
+        value: advise & 0x4 == 0x4
+      inline_pcluster:
+        value: advise & 0x8 == 0x8
+      interlaced_pcluster:
+        value: advise & 0x10 == 0x10
+      interlaced_fragment_pcluster:
+        value: advise & 0x20 == 0x20
       algorithm_type_head_1:
         value: algorithm_type & 0xf
         enum: compression

--- a/src/bang/parsers/filesystem/erofs/erofs.ksy
+++ b/src/bang/parsers/filesystem/erofs/erofs.ksy
@@ -262,6 +262,7 @@ types:
         enum: file_types
       - id: reserved
         type: u1
+    instances:
       inode:
         io: _root._io
         pos: _root.inode_offset_base + 32 * node_id

--- a/src/bang/parsers/filesystem/erofs/erofs.ksy
+++ b/src/bang/parsers/filesystem/erofs/erofs.ksy
@@ -190,7 +190,6 @@ types:
       - id: num_inline_xattr
         -orig-id: i_xattr_icount
         type: u2
-        #valid: 0
       - id: mode
         type: u2
       - id: body

--- a/src/bang/parsers/filesystem/erofs/erofs.ksy
+++ b/src/bang/parsers/filesystem/erofs/erofs.ksy
@@ -333,6 +333,8 @@ types:
         type: str
       - id: value
         size: len_value
+      - id: padding
+        size: -(len_value + len_name) % 4
   chunk_info:
     seq:
       - id: format

--- a/src/bang/parsers/filesystem/erofs/erofs.ksy
+++ b/src/bang/parsers/filesystem/erofs/erofs.ksy
@@ -389,6 +389,43 @@ types:
         type: inode
       name:
         value: _parent.names[index]
+
+  map_header:
+    seq:
+      - id: offset_or_encoded_size
+        size: 4
+        type: map_header_union
+      - id: advise
+        type: u2
+      - id: algorithm_type
+        type: u1
+      - id: cluster_bits
+        type: u1
+    instances:
+      algorithm_type_head_1:
+        value: algorithm_type & 0xf
+        enum: compression
+      algorithm_type_head_2:
+        value: algorithm_type >> 4
+        enum: compression
+      whole_file_packed:
+        value: cluster_bits >> 7
+      logical_cluster_bits:
+        value: (cluster_bits & 0x7) + 12
+      logical_cluster_size:
+        value: 1 << logical_cluster_bits
+    types:
+      map_header_union:
+        seq:
+          - id: raw
+            size: 4
+        instances:
+          ofs_fragment:
+            pos: 0
+            type: u4
+          len_encoded_tailpacking_data:
+            pos: 2
+            type: u2
   lz4_configs:
     seq:
       - id: max_distance

--- a/src/bang/parsers/filesystem/erofs/erofs.ksy
+++ b/src/bang/parsers/filesystem/erofs/erofs.ksy
@@ -389,6 +389,22 @@ types:
         type: inode
       name:
         value: _parent.names[index]
+  lz4_configs:
+    seq:
+      - id: max_distance
+        type: u2
+      - id: max_pcluster_blocks
+        type: u2
+      - id: reserved
+        size: 10
+  lzma_configs:
+    seq:
+      - id: dict_size
+        type: u4
+      - id: format
+        type: u2
+      - id: reserved
+        size: 8
 enums:
   file_types:
     0: unknown

--- a/src/bang/parsers/filesystem/erofs/erofs.ksy
+++ b/src/bang/parsers/filesystem/erofs/erofs.ksy
@@ -386,6 +386,8 @@ types:
         io: _root._io
         pos: _root.ofs_metadata_area + (32 * node_id)
         type: inode
+      name:
+        value: _parent.names[index]
 enums:
   file_types:
     0: unknown

--- a/src/bang/parsers/filesystem/erofs/erofs.ksy
+++ b/src/bang/parsers/filesystem/erofs/erofs.ksy
@@ -397,6 +397,15 @@ types:
       - id: file_type
         type: u1
         enum: file_types
+        valid:
+          any-of:
+            - file_types::regular_file
+            - file_types::directory
+            - file_types::character_device
+            - file_types::block_device
+            - file_types::fifo
+            - file_types::socket
+            - file_types::symlink
       - id: reserved
         type: u1
     instances:


### PR DESCRIPTION
This PR adds support for a subset of erofs, namely the "inline" data layout. Compressed data (which most file systems will use) is not yet supported. Chunked mode (used in erofs for cloud images) is also not yet supported. Therefore this should mostly be regarded as scaffolding.