### PR TITLE
Priorities

### DIFF
--- a/doc/writing-parsers.md
+++ b/doc/writing-parsers.md
@@ -41,10 +41,10 @@ and also parsers that are using external tools, such as:
 1. `SevenzipUnpackParser`
 2. `RzipUnpackParser`
 
-## `extensions` and `signatures`
+## `extensions`, `signatures` and `priority`
 
 The two data structures `extensions` and `signatures` are defined that define
-parser class is used. They are independent from each other.
+which parser class is used. They are independent from each other.
 
 Normally parsers rely on signatures (AKA "magic") to find the start of where
 a file format starts, but not all files have a signature. For example, the
@@ -72,6 +72,20 @@ When deciding if `extensions` or `signatures` should be used the rule of thumb
 is that if there is a signature, then `signatures` should be used and
 `extensions` should not be used. If there is no signature but there is a
 reliable extension, then `extensions` should be used.
+
+`priority` is used to indicate an optional priority when scanning. There
+are situations when there are parser classes that match, but where one should
+be preferred over the other. An example is ISO9660, where the first block
+of the file system could contain anything, for example a bootblock with
+an EFI bootloader. In this case the ISO9660 parser should be run,
+otherwise it will be hard to extract the content (at least not until polyglot
+files are supported. By default all parsers have a `priority` of `0`. To make
+sure that a particular unpacker is used first the `priority` field can be set
+to a higher number, for example:
+
+```
+    priority = 1000
+```
 
 ## `pretty_name`
 

--- a/src/bang/UnpackParser.py
+++ b/src/bang/UnpackParser.py
@@ -80,6 +80,7 @@ class UnpackParser:
     Override any methods if necessary.
     """
     extensions = []
+    priority = 0
 
     signatures = []
     scan_if_featureless = False

--- a/src/bang/cli.py
+++ b/src/bang/cli.py
@@ -121,6 +121,7 @@ def scan(config_file, verbose, unpack_directory, temporary_directory, jobs, job_
 
     #log.debug(f'{unpack_parsers =}')
     scan_environment.parsers.build_automaton()
+    scan_environment.signature_chunk_size = max(scan_environment.signature_chunk_size, scan_environment.parsers.max_chunk_size)
 
     # set up the process manager and initialize the barrier
     # with the value of the amount of jobs: this is the maximum

--- a/src/bang/parsers/filesystem/iso9660/UnpackParser.py
+++ b/src/bang/parsers/filesystem/iso9660/UnpackParser.py
@@ -43,6 +43,7 @@ class Iso9660UnpackParser(UnpackParser):
         (32769, b'CD001')
     ]
     pretty_name = 'iso9660'
+    priority = 1000
 
     def parse(self):
         self.zisofs = False

--- a/src/bang/scan_environment.py
+++ b/src/bang/scan_environment.py
@@ -57,6 +57,7 @@ class ParserCollection:
         self._unpackparsers_for_signatures = {}
         self._unpackparsers_for_featureless_files = []
         self.longest_signature_length = 0
+        self.max_chunk_size = 0
 
     def add(self, unpackparser):
         self._unpackparsers[unpackparser.pretty_name] = unpackparser
@@ -114,6 +115,7 @@ class ParserCollection:
                 else:
                     self._automaton.add_word(s[1], (s[0]+len(s[1])-1, [u]))
                 self.longest_signature_length = max(self.longest_signature_length, len(s[1]))
+                self.max_chunk_size = max(self.max_chunk_size, s[0] + len(s[1]))
 
         if len(self._automaton) > 0:
             self._automaton.make_automaton()

--- a/src/bang/scan_job.py
+++ b/src/bang/scan_job.py
@@ -252,10 +252,12 @@ def find_signature_parsers(scan_environment, open_file, file_scan_state, file_si
                 if offset not in found_parsers:
                     found_parsers[offset] = []
                 found_parsers[offset] += unpack_parser_cls
-                #yield offset, unpack_parser_cls
 
+        # sort the parsers found based on offsets
         for offset in sorted(found_parsers):
+            # sort the parsers found at each offset based on priority
             yield offset, sorted(found_parsers[offset], key=lambda x: x.priority, reverse=True)
+
         if file_scan_state.chunk_start + len(s) >= file_size:
             # this was the last chunk
             file_scan_state.chunk_start += len(s)

--- a/src/bang/scan_job.py
+++ b/src/bang/scan_job.py
@@ -233,6 +233,12 @@ def find_signature_parsers(scan_environment, open_file, file_scan_state, file_si
         open_file.seek(file_scan_state.chunk_start)
         s = open_file.read(chunk_size)
         #log.debug(f'find_signature_parsers: read [{file_scan_state.chunk_start}:+{len(s)}]')
+
+        # store the parsers found so far instead of yielding every found
+        # parser as the offset possibly needs to be corrected because
+        # the signature doesn't appear at the start of the file
+        # (examples: MBR, ISO9660).
+        found_parsers = []
         for end_index, (end_difference, unpack_parser_cls) in scan_environment.parsers.automaton.iter(s):
             offset = file_scan_state.chunk_start + end_index - end_difference
             #log.debug(f'find_signature_parsers: got match at [{offset}:{file_scan_state.chunk_start+end_index}]')
@@ -243,7 +249,11 @@ def find_signature_parsers(scan_environment, open_file, file_scan_state, file_si
                 #log.debug(f'find_signature_parsers: match falls within overlap: {end_index=} < {chunk_overlap=}')
                 pass
             else:
-                yield offset, unpack_parser_cls
+                found_parsers.append((offset, unpack_parser_cls))
+                #yield offset, unpack_parser_cls
+
+        for offset, unpack_parser_cls in sorted(found_parsers, key=itemgetter(0)):
+            yield offset, unpack_parser_cls
         if file_scan_state.chunk_start + len(s) >= file_size:
             # this was the last chunk
             file_scan_state.chunk_start += len(s)

--- a/src/bang/scan_job.py
+++ b/src/bang/scan_job.py
@@ -238,7 +238,7 @@ def find_signature_parsers(scan_environment, open_file, file_scan_state, file_si
         # parser as the offset possibly needs to be corrected because
         # the signature doesn't appear at the start of the file
         # (examples: MBR, ISO9660).
-        found_parsers = []
+        found_parsers = {}
         for end_index, (end_difference, unpack_parser_cls) in scan_environment.parsers.automaton.iter(s):
             offset = file_scan_state.chunk_start + end_index - end_difference
             #log.debug(f'find_signature_parsers: got match at [{offset}:{file_scan_state.chunk_start+end_index}]')
@@ -249,11 +249,13 @@ def find_signature_parsers(scan_environment, open_file, file_scan_state, file_si
                 #log.debug(f'find_signature_parsers: match falls within overlap: {end_index=} < {chunk_overlap=}')
                 pass
             else:
-                found_parsers.append((offset, unpack_parser_cls))
+                if offset not in found_parsers:
+                    found_parsers[offset] = []
+                found_parsers[offset] += unpack_parser_cls
                 #yield offset, unpack_parser_cls
 
-        for offset, unpack_parser_cls in sorted(found_parsers, key=itemgetter(0)):
-            yield offset, unpack_parser_cls
+        for offset in sorted(found_parsers):
+            yield offset, sorted(found_parsers[offset], key=lambda x: x.priority, reverse=True)
         if file_scan_state.chunk_start + len(s) >= file_size:
             # this was the last chunk
             file_scan_state.chunk_start += len(s)


### PR DESCRIPTION
This PR fixes a few shortcomings:

1. sorts parsers based on offsets after any corrections of offsets (example: ISO9660, MBR)
2. introduces a priority system to ensure parsers can be run before other in case they have the same offset (example: ISO9660 with EFI boot block)
3. dynamically determines the size of the chunk that's scanned based on parser offsets and signature lengths