### PR TITLE
uimage: explicitly set the length for the name field.

### DIFF
--- a/src/bang/parsers/firmware/uboot/uimage.ksy
+++ b/src/bang/parsers/firmware/uboot/uimage.ksy
@@ -102,6 +102,7 @@ types:
       - id: name
         encoding: UTF-8
         type: strz
+        size-eos: true
     instances:
       asus_info:
         pos: 0


### PR DESCRIPTION
There are some uboot images out there (like several Anjvision IP camera firmware files) where the image name is not NULL terminated. By explicitly setting the length Kaitai Struct will use the length of the field, instead of trying to search for a terminator.