### PR TITLE
support for ANJvision IP camera firmware files

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ larger file, unless stated otherwise.
 208. Realtek bootloader (subset of files)
 209. Linux kernel x86 images
 210. TP-Link minifs
+211. ANJVision IP camera firmware files
 
 ## Getting started
 

--- a/doc/firmware-test-notes.md
+++ b/doc/firmware-test-notes.md
@@ -126,3 +126,7 @@ Zephyr firmware.
 ## TL-R460_v5.0_120704_RU_UA.zip
 
 TP-Link TL-R460, uses `vxworks_memfs`
+
+## ANJVision firmware files
+
+<http://www.anjvision.com:8021/firmware/>

--- a/src/bang/parsers/firmware/anjvision/UnpackParser.py
+++ b/src/bang/parsers/firmware/anjvision/UnpackParser.py
@@ -1,0 +1,58 @@
+# Binary Analysis Next Generation (BANG!)
+#
+# This file is part of BANG.
+#
+# BANG is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License, version 3,
+# as published by the Free Software Foundation.
+#
+# BANG is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License, version 3, along with BANG.  If not, see
+# <http://www.gnu.org/licenses/>
+#
+# Copyright Armijn Hemel
+# Licensed under the terms of the GNU Affero General Public License
+# version 3
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import pathlib
+
+from bang.UnpackParser import UnpackParser, check_condition
+from bang.UnpackParserException import UnpackParserException
+from kaitaistruct import ValidationFailedError
+from . import anjvision
+
+
+class AnjvisionUnpackParser(UnpackParser):
+    extensions = []
+    signatures = [
+        (0, b'ANJOY888')
+    ]
+    pretty_name = 'anjvision'
+
+    def parse(self):
+        try:
+            self.data = anjvision.Anjvision.from_io(self.infile)
+
+        except (Exception, ValidationFailedError) as e:
+            raise UnpackParserException(e.args)
+
+    def unpack(self, meta_directory):
+        file_path = pathlib.Path('u-boot')
+        with meta_directory.unpack_regular_file(file_path) as (unpacked_md, outfile):
+            outfile.write(self.data.uboot)
+            yield unpacked_md
+
+        file_path = pathlib.Path('fs')
+        with meta_directory.unpack_regular_file(file_path) as (unpacked_md, outfile):
+            outfile.write(self.data.file_system)
+            yield unpacked_md
+
+
+    labels = ['anjvision', 'firmware']
+    metadata = {}

--- a/src/bang/parsers/firmware/anjvision/anjvision.ksy
+++ b/src/bang/parsers/firmware/anjvision/anjvision.ksy
@@ -1,0 +1,36 @@
+meta:
+  id: anjvision
+  title: ANJVision firmware image
+  endian: le
+  license: CC0-1.0
+doc: |
+  ANJVision is a Chinese manufacturer of IP cameras. The company uses
+  its own firmware format, which is a fairly simple wrapper around U-boot
+  and a file system. So far the only observed file system is Squashfs.
+seq:
+  - id: header
+    type: header
+  - id: rest_of_header
+    size: header.len_header - header._sizeof
+  - id: uboot
+    size: header.len_data
+  - id: file_system
+    size: header.len_file - header.len_data - header.len_header
+types:
+  header:
+    seq:
+      - id: magic
+        contents: 'ANJOY888'
+      - id: unknown
+        size: 4
+      - id: len_file
+        type: u4
+      - id: unknown_1
+        type: u4
+        valid: 3
+      - id: len_header
+        type: u4
+      - id: len_data
+        type: u4
+      - id: unknown_2
+        type: u4


### PR DESCRIPTION
This PR adds support for the firmware file format as used by ANJvision, a Chinese IP camera manufacturer. The format seems to be a fairly simple wrapper around u-boot and squashfs, with some additional metadata.