### PR TITLE
Metadirectory refactor

### DIFF
--- a/doc/bang-design.md
+++ b/doc/bang-design.md
@@ -140,8 +140,9 @@ directories. It also contains general metadata and unpacked symlinks.
 
 Unpacked files that have absolute paths can be found under `abs`, while those
 with relative paths are under `rel`. Files that are carved from a larger file
-are stored in a directory `extracted`. Files like boot blocks (example: ISO9660
-file systems) are stored in the directory `block`.
+are stored in a directory `extracted`. Extra data like boot blocks (example:
+ISO9660 file systems) or file comments (example: ZIP file comments and archive
+comments) are stored in the directory `extra`.
 
 This structure makes it harder to navigate unpacked results, but unpacked files
 will not clutter the directory structure. To navigate the results there are

--- a/src/bang/meta_directory.py
+++ b/src/bang/meta_directory.py
@@ -246,7 +246,7 @@ class MetaDirectory:
         if is_extradata:
             unpacked_path = self.unpacked_extradata_root / path_name
         else:
-            if path.is_absolute():
+            if path_name.is_absolute():
                 unpacked_path = self.unpacked_abs_root / path_name
             else:
                 unpacked_path = self.unpacked_rel_root / path_name

--- a/src/bang/meta_directory.py
+++ b/src/bang/meta_directory.py
@@ -42,7 +42,6 @@ class MetaDirectoryException(Exception):
 
 class MetaDirectory:
     ABS_UNPACK_DIR = 'abs'
-    BLOCK_UNPACK_DIR = 'block'
     EXTRA_UNPACK_DIR = 'extra'
     REL_UNPACK_DIR = 'rel'
     ROOT_PATH = 'root'
@@ -220,10 +219,6 @@ class MetaDirectory:
         return self.md_path / self.REL_UNPACK_DIR
 
     @property
-    def unpacked_block_root(self):
-        return self.md_path / self.BLOCK_UNPACK_DIR
-
-    @property
     def unpacked_extradata_root(self):
         return self.md_path / self.EXTRA_UNPACK_DIR
 
@@ -245,11 +240,11 @@ class MetaDirectory:
 
         return (path_name, is_absolute)
 
-    def unpacked_path(self, path_name, is_block=False):
+    def unpacked_path(self, path_name, is_extradata=False):
         '''Gives a path in the MetaDirectory for an unpacked file with name path_name.
         '''
-        if is_block:
-            unpacked_path = self.unpacked_block_root / path_name
+        if is_extradata:
+            unpacked_path = self.unpacked_extradata_root / path_name
         else:
             if path.is_absolute():
                 unpacked_path = self.unpacked_abs_root / path_name
@@ -285,13 +280,13 @@ class MetaDirectory:
         return md, f
 
     @contextmanager
-    def unpack_regular_file_no_open(self, path, is_block=False):
+    def unpack_regular_file_no_open(self, path, is_extradata=False):
         '''Context manager for unpacking a file with path path into the MetaDirectory,
         yields a file name, that can be used to write data to.
         '''
         sanitized_path, is_absolute = self.sanitize_path(path)
 
-        unpacked_path = self.unpacked_path(sanitized_path, is_block)
+        unpacked_path = self.unpacked_path(sanitized_path, is_extradata)
         unpacked_md, unpacked_file = self.make_new_md_for_file(unpacked_path)
         unpacked_file.close()
 
@@ -301,8 +296,8 @@ class MetaDirectory:
         yield unpacked_md, unpacked_file.name
 
         # update info
-        if is_block:
-            self.info.setdefault('unpacked_block_files', {})[unpacked_path] = unpacked_md.md_path
+        if is_extradata:
+            self.info.setdefault('unpacked_extradata_files', {})[unpacked_path] = unpacked_md.md_path
         else:
             if absolute:
                 self.info.setdefault('unpacked_absolute_files', {})[unpacked_path] = unpacked_md.md_path
@@ -311,14 +306,14 @@ class MetaDirectory:
         log.debug(f'[{self.md_path}]unpack_regular_file: update info to {self.info}')
 
     @contextmanager
-    def unpack_regular_file(self, path, is_block=False):
+    def unpack_regular_file(self, path, is_extradata=False):
         '''Context manager for unpacking a file with path path into the MetaDirectory,
         yields a file object, that you can write to, directly or via sendfile().
         '''
 
         sanitized_path, is_absolute = self.sanitize_path(path)
 
-        unpacked_path = self.unpacked_path(sanitized_path, is_block)
+        unpacked_path = self.unpacked_path(sanitized_path, is_extradata)
         unpacked_md, unpacked_file = self.make_new_md_for_file(unpacked_path)
         try:
             yield unpacked_md, unpacked_file
@@ -330,8 +325,8 @@ class MetaDirectory:
             unpacked_md.size = unpacked_path.stat().st_size
 
         # update info
-        if is_block:
-            self.info.setdefault('unpacked_block_files', {})[unpacked_path] = unpacked_md.md_path
+        if is_extradata:
+            self.info.setdefault('unpacked_extradata_files', {})[unpacked_path] = unpacked_md.md_path
         else:
             if is_absolute:
                 self.info.setdefault('unpacked_absolute_files', {})[unpacked_path] = unpacked_md.md_path
@@ -392,7 +387,7 @@ class MetaDirectory:
 
     @property
     def unpacked_files(self):
-        return self.unpacked_relative_files | self.unpacked_absolute_files | self.unpacked_block_files
+        return self.unpacked_relative_files | self.unpacked_absolute_files | self.unpacked_extradata_files
 
     @property
     def unpacked_relative_files(self):
@@ -407,9 +402,9 @@ class MetaDirectory:
         return files
 
     @property
-    def unpacked_block_files(self):
-        files =  self.info.get('unpacked_block_files',{})
-        log.debug(f'[{self.md_path}]unpacked_block_files: got {files}')
+    def unpacked_extradata_files(self):
+        files =  self.info.get('unpacked_extradata_files',{})
+        log.debug(f'[{self.md_path}]unpacked_extradata_files: got {files}')
         return files
 
     @contextmanager

--- a/src/bang/parsers/archivers/zip/UnpackParser.py
+++ b/src/bang/parsers/archivers/zip/UnpackParser.py
@@ -710,6 +710,12 @@ class ZipUnpackParser(UnpackParser):
                         with meta_directory.unpack_regular_file(file_path) as (unpacked_md, outfile):
                             outfile.write(unpackzipfile.read(z))
                             yield unpacked_md
+                        if z.comment != b'':
+                            suffix = file_path.suffix + '.file_comment'
+                            file_path = file_path.with_suffix(suffix)
+                            with meta_directory.unpack_regular_file(file_path, is_extradata=True) as (unpacked_md, outfile):
+                                outfile.write(z.comment)
+                                yield unpacked_md
                     else:
                         meta_directory.unpack_directory(file_path)
                 except NotADirectoryError:

--- a/src/bang/parsers/archivers/zip/UnpackParser.py
+++ b/src/bang/parsers/archivers/zip/UnpackParser.py
@@ -690,10 +690,11 @@ class ZipUnpackParser(UnpackParser):
             file_path = pathlib.Path(*clean_file_path_parts)
 
             # Absolute paths are not permitted according to the ZIP
-            # specification so rework to relative paths. TODO: this
+            # specification so rework to relative paths. This
             # means that the files will be unpacked in the "rel"
-            # directory instead of the "abs" directory. Is this intended
-            # behaviour or should it be changed?
+            # directory instead of the "abs" directory. This is
+            # intended behaviour and consistent with how other tools
+            # unpack data.
             if file_path.is_absolute():
                 try:
                     file_path = file_path.relative_to('/')

--- a/src/bang/parsers/archivers/zip/UnpackParser.py
+++ b/src/bang/parsers/archivers/zip/UnpackParser.py
@@ -209,7 +209,7 @@ class ZipUnpackParser(UnpackParser):
                             # which one is used possibly only until after it has
                             # been read.
                             # A hint is the ZIP version: if it is 4.5 or higher
-                            # then it is very likely that it is the ZIP64
+                            # then it is very likely that it is the ZIP64 variant
                             if zip_version >= 45:
                                 self.infile.seek(start_of_entry)
                                 try:

--- a/src/bang/parsers/archivers/zip/UnpackParser.py
+++ b/src/bang/parsers/archivers/zip/UnpackParser.py
@@ -655,6 +655,14 @@ class ZipUnpackParser(UnpackParser):
                 os.unlink(self.temporary_file[1])
             return
 
+        if self.zip_comment != b'':
+            file_path = pathlib.Path(pathlib.Path(self.infile.name).name)
+            suffix = file_path.suffix + '.comment'
+            file_path = file_path.with_suffix(suffix)
+            with meta_directory.unpack_regular_file(file_path, is_extradata=True) as (unpacked_md, outfile):
+                outfile.write(self.zip_comment)
+                yield unpacked_md
+
         if not self.carved:
             unpackzipfile = zipfile.ZipFile(self.infile)
         else:
@@ -801,6 +809,5 @@ class ZipUnpackParser(UnpackParser):
                 pass
 
         metadata = {}
-        metadata['comment'] = self.zip_comment
         metadata['zip type'] = labels
         return metadata

--- a/src/bang/parsers/archivers/zip/zip.ksy
+++ b/src/bang/parsers/archivers/zip/zip.ksy
@@ -260,9 +260,7 @@ types:
             true: empty
             false: extras(section_types::central_dir_entry)
       - id: comment
-        type: str
         size: len_comment
-        encoding: UTF-8
     instances:
       local_header:
         pos: ofs_local_header

--- a/src/bang/parsers/filesystem/iso9660/UnpackParser.py
+++ b/src/bang/parsers/filesystem/iso9660/UnpackParser.py
@@ -304,7 +304,7 @@ class Iso9660UnpackParser(UnpackParser):
         # useful information, but which are not really part of the contents
         # of an ISO image, so this should be written to a separate directory
         file_path = pathlib.Path('system_area')
-        with meta_directory.unpack_regular_file(file_path, is_block=True) as (unpacked_md, outfile):
+        with meta_directory.unpack_regular_file(file_path, is_extradata=True) as (unpacked_md, outfile):
             outfile.write(self.data.system_area)
             yield unpacked_md
 


### PR DESCRIPTION
Replace "block" with "extra data", add an extra example (apart from ISO9660) of extra data (ZIP file comments and archive comments).