### PR TITLE
Update ELF section name from 'esstra_info' to '.esstra'

### DIFF
--- a/src/bang/parsers/executable/elf/UnpackParser.py
+++ b/src/bang/parsers/executable/elf/UnpackParser.py
@@ -391,7 +391,7 @@ class ElfUnpackParser(UnpackParser):
                 # * .rom_info: Mediatek preloader(?)
                 # * .init.data: Linux kernel init data, sometimes contains initial ramdisk
                 if header.name in ['.gnu_debugdata', '.qtmimedatabase', '.BTF', '.BTF.ext',
-                                   '.rom_info', '.init.data', 'esstra_info']:
+                                   '.rom_info', '.init.data', '.esstra']:
                     interesting = True
 
                 # GNOME/glib GVariant database


### PR DESCRIPTION
This pull request updates the ELF section name used in `UnpackParser.py` from `esstra_info` to `.esstra`.

Reference: https://github.com/sony/esstra/blob/main/core/esstracore.cpp#L58