### PR TITLE
Add "parser" for hints

### DIFF
--- a/src/bang/UnpackParser.py
+++ b/src/bang/UnpackParser.py
@@ -263,6 +263,45 @@ class ExtractingParser(UnpackParser):
         '''TODO: write any data about the parent MetaDirectory here.'''
         pass
 
+class HintParser(UnpackParser):
+    '''Parser to record hints for files, based on:
+
+       * extensions
+       * parsing partial content (after checking extensions)
+
+       This is useful for files for which there is a strong
+       suspicion that a file is a certain type of file.'''
+
+    def __init__(self, from_meta_directory, offset, configuration):
+        super().__init__(from_meta_directory, offset, configuration)
+        self.from_md = from_meta_directory
+        self.offset = offset
+        self.hints = []
+
+    pretty_name = 'hintparser'
+
+    def parse(self):
+        # reset the file pointer to extract strings
+        self.infile.seek(self.offset)
+
+        # start reading data in chunks of 10 MiB
+        read_size = 10485760
+
+        if self.hints:
+            self.update_metadata(self.from_md)
+            self.from_md.write_ahead()
+
+    def calculate_unpacked_size(self):
+        self.unpacked_size = 0
+
+    labels = []
+
+    @property
+    def metadata(self):
+        metadata = self.from_md.info.get('metadata', {})
+        metadata['hints'] = self.hints
+        return metadata
+
 class StringExtractingParser(UnpackParser):
     '''Parser to extract human readable ASCII strings from binaries'''
     # characters to be removed when extracting strings

--- a/src/bang/UnpackParser.py
+++ b/src/bang/UnpackParser.py
@@ -19,7 +19,6 @@
 
 import hashlib
 import os
-import pathlib
 
 import tlsh
 
@@ -202,13 +201,18 @@ class SynthesizingParser(UnpackParser):
 
     def unpack(self, to_meta_directory):
         # synthesized files must be scanned again (with featureless parsers),
-        # so let them unpack themselves # but first, write the info data before
-        # the meta directory is queued.
+        # so let them unpack themselves, but first write the info data before
+        # the meta directory is queued in the scan queue.
         to_meta_directory.write_ahead()
         yield to_meta_directory
 
 
 class PaddingParser(UnpackParser):
+    '''Parser to determine if a file contains padding. Padding means
+       one or more copies of a character from valid_padding_chars.
+       A padding file can only contain a single unique character (meaning
+       that different padding characters cannot be mixed).
+    '''
 
     valid_padding_chars = [b'\x00', b'\xff']
 

--- a/src/bang/UnpackParser.py
+++ b/src/bang/UnpackParser.py
@@ -270,7 +270,19 @@ class HintParser(UnpackParser):
        * parsing partial content (after checking extensions)
 
        This is useful for files for which there is a strong
-       suspicion that a file is a certain type of file.'''
+       suspicion that a file is a certain type of file.
+
+       Instead of trying to be generic (and for example leveraging
+       mime types) this is hand crafted to increase fidelity and to
+       be able do do a few extra checks.
+    '''
+
+    # a mapping of extensions to file type
+    EXTENSIONS = {'.sh': 'shell script',
+                  '.css': 'CSS',
+                  '.html': 'HTML',
+                  '.js': 'JavaScript',
+                  '.php': 'PHP'}
 
     def __init__(self, from_meta_directory, offset, configuration):
         super().__init__(from_meta_directory, offset, configuration)
@@ -281,7 +293,9 @@ class HintParser(UnpackParser):
     pretty_name = 'hintparser'
 
     def parse(self):
-        # reset the file pointer to extract strings
+        extension = self.infile.name.suffix
+
+        # reset the file pointer to the start of the file
         self.infile.seek(self.offset)
 
         # start reading data in chunks of 10 MiB

--- a/src/bang/UnpackParser.py
+++ b/src/bang/UnpackParser.py
@@ -283,11 +283,9 @@ class HintParser(UnpackParser):
     '''
 
     # a mapping of extensions to file type
-    EXTENSIONS = {'.sh': 'shell script',
-                  '.css': 'CSS',
-                  '.html': 'HTML',
-                  '.js': 'JavaScript',
-                  '.php': 'PHP'}
+    EXTENSIONS = {'.sh': 'shell script', '.css': 'CSS',
+                  '.html': 'HTML', '.js': 'JavaScript',
+                  '.php': 'PHP', '.h': 'C/C++ header file'}
 
     def __init__(self, from_meta_directory, offset, configuration):
         super().__init__(from_meta_directory, offset, configuration)

--- a/src/bang/UnpackParser.py
+++ b/src/bang/UnpackParser.py
@@ -19,6 +19,7 @@
 
 import hashlib
 import os
+import pathlib
 
 import tlsh
 
@@ -292,18 +293,21 @@ class HintParser(UnpackParser):
         super().__init__(from_meta_directory, offset, configuration)
         self.from_md = from_meta_directory
         self.offset = offset
-        self.hints = []
+        self.hints = {}
 
     pretty_name = 'hintparser'
 
     def parse(self):
-        extension = self.infile.name.suffix
+        extension = pathlib.Path(self.infile.name).suffix
 
         # reset the file pointer to the start of the file
         self.infile.seek(self.offset)
 
         # start reading data in chunks of 10 MiB
         read_size = 10485760
+
+        if extension in self.EXTENSIONS:
+            self.hints['extension'] = self.EXTENSIONS[extension]
 
         if self.hints:
             self.update_metadata(self.from_md)

--- a/src/bang/scan_job.py
+++ b/src/bang/scan_job.py
@@ -156,6 +156,20 @@ def extract_strings(scan_environment, checking_meta_directory):
         pass
 
 #####
+# Finds hints about files and writes to the meta_directory
+#
+def find_hints(scan_environment, checking_meta_directory):
+    '''Finds hints about files and writes to the meta_directory'''
+    try:
+        labels = checking_meta_directory.info.get('labels', [])
+        if not labels:
+            pass
+    except UnpackParserException:
+        # there will be a "parser resulted in zero length file"
+        # warning, but ignore that.
+        pass
+
+#####
 #
 # Iterator that yields all combinations of extensions and UnpackParsers.
 # We cannot do a direct lookup, since we do not know the extension in advance, for example

--- a/src/bang/scan_job.py
+++ b/src/bang/scan_job.py
@@ -25,7 +25,7 @@ import traceback
 import time
 from dataclasses import dataclass
 from .meta_directory import *
-from .UnpackParser import SynthesizingParser, ExtractedParser, ExtractingParser, PaddingParser, StringExtractingParser, TlshParser, compute_hashes
+from .UnpackParser import SynthesizingParser, ExtractedParser, ExtractingParser, HintParser, PaddingParser, StringExtractingParser, TlshParser, compute_hashes
 from .UnpackParserException import UnpackParserException
 from .log import log
 
@@ -163,7 +163,14 @@ def find_hints(scan_environment, checking_meta_directory):
     try:
         labels = checking_meta_directory.info.get('labels', [])
         if not labels:
-            pass
+            unpack_parser = HintParser(checking_meta_directory, 0, scan_environment.configuration)
+            log.debug(f'find_hints[{checking_meta_directory.md_path}]: trying parse for {checking_meta_directory.file_path} with {unpack_parser.__class__} [{time.time_ns()}]')
+
+            checking_meta_directory.unpack_parser = unpack_parser
+            unpack_parser.parse_from_offset()
+            log.debug(f'find_hints[{checking_meta_directory.md_path}]: successful parse for {checking_meta_directory.file_path} with {unpack_parser.__class__} [{time.time_ns()}]')
+            log.debug(f'find_hints[{checking_meta_directory.md_path}]: parsed_size = {unpack_parser.parsed_size}/{checking_meta_directory.size}')
+            yield checking_meta_directory
     except UnpackParserException:
         # there will be a "parser resulted in zero length file"
         # warning, but ignore that.
@@ -641,6 +648,7 @@ def make_scan_pipeline():
 
     pipe_hashes = pipe_exec(compute_tlsh_hash)
     pipe_strings = pipe_exec(extract_strings)
+    pipe_hints = pipe_exec(find_hints)
 
     pipe_checks_if_not_synthesized = pipe_cond(
             cond_not_synthesized,
@@ -664,6 +672,7 @@ def make_scan_pipeline():
         cond_scannable,
         pipe_with(ctx_open_md_for_writing, pipe_scan),
         pipe_fail), pipe_with(ctx_open_md_for_writing, pipe_hashes),
+        pipe_with(ctx_open_md_for_writing, pipe_hints),
         pipe_with(ctx_open_md_for_writing, pipe_strings)
     )
     return pipe_root


### PR DESCRIPTION
This PR adds a parser that records hints about what a file that wasn't successfully parsed (but which might or might not have subfiles) could contain, as a lower confidence hint. Right now the only hint that is recorded is the extension. The list of extensions is hard coded and rather small, as this just an extra.